### PR TITLE
Fix Viewer.js typo and Add SimpleMode on Viewer.js

### DIFF
--- a/src/component/Viewer.js
+++ b/src/component/Viewer.js
@@ -252,7 +252,7 @@
         throw new TypeError("chat must be object: " + typeof chat);
 
       if (this._comment.has(chat))
-        return this.comment.get(chat);
+        return this._comment.get(chat);
 
       var elem = document.createElement("jikkyo-chat");
       elem.chat = chat;

--- a/src/component/ViewerAdapter.js
+++ b/src/component/ViewerAdapter.js
@@ -20,6 +20,9 @@
       this._duration = 4000;
       this._durationAlt = 3000;
 
+      this._refreshCb = null;
+      this._simpleLength = 1000;
+
       this._event = new EventEmitter();
 
       this._renderComment = [];
@@ -115,6 +118,7 @@
       this._position = Math.min(this._length, position);
 
       this._event.emit("observe", "position", this._position);
+      if (this.isSimpleMode) this.refresh();
     }
 
     get length() {
@@ -131,6 +135,24 @@
 
       this._event.emit("observe", "length", this._length);
       this._event.emit("observe", "position", this._position);
+    }
+
+    get simpleLength() {
+      return this._simpleLength;
+    }
+
+    set simpleLength(simpleLength) {
+      if (typeof simpleLength !== "number")
+        throw new TypeError("simpleLength must be number: " + typeof simpleLength);
+      if (this.simpleLength === simpleLength) return;
+
+      this._simpleLength = simpleLength;
+
+      if (this.isSimpleMode) this.refresh();
+    }
+
+    get isSimpleMode() {
+      return !this._realtime && this._comment.length > this._simpleLength;
     }
 
     on(listener) {
@@ -201,46 +223,74 @@
     render() {
       if (this._viewer === null) return;
 
-      var rComment = this._renderComment;
-      var viewer = this._viewer;
-
-      this._comment.forEach(chat => {
-        // renderComment内にchatが存在するか
-        if (rComment.includes(chat)) {
-          // 表示されるか
-          if (this._isVisible(chat)) {
-            chat.x = this._calcX(chat);
-          } else {
-            chat.visibility = false;
-            viewer.removeChat(chat);
-            rComment.splice(rComment.indexOf(chat), 1);
-            if (this._realtime)
-              this._comment.splice(this._comment.indexOf(chat), 1);
-          }
-        } else if (this._isVisible(chat)) {
+      this._renderComment.slice().forEach(chat => {
+        if (this._isVisible(chat)) {
           chat.x = this._calcX(chat);
+        } else {
+          chat.visibility = false;
+          this._viewer.removeChat(chat);
+          this._renderComment.splice(this._renderComment.indexOf(chat), 1);
 
-          // コメントが上限に達しているか
-          if (rComment.length === this._limit) {
-            viewer.removeChat(rComment[0]);
-            rComment.shift();
-          }
-
-          chat.visibility = true;
-          viewer.createChat(chat);
-          rComment.splice(this._binarySearch(chat, rComment), 0, chat);
+          if (this._realtime)
+            this._comment.splice(this._comment.indexOf(chat), 1);
         }
+      }, this);
+
+      this._comment.slice().forEach(chat => {
+        if (!this._isVisible(chat)) return;
+        if (this._renderComment.includes(chat)) return;
+
+        chat.x = this._calcX(chat);
+
+        if (this._renderComment.length === this._limit) {
+          this._viewer.removeChat(this._renderComment[0]);
+          this._renderComment.shift();
+        }
+
+        chat.visibility = true;
+        this._viewer.createChat(chat);
+        this._renderComment.splice(this._binarySearch(chat, this._renderComment), 0, chat);
       }, this);
     }
 
     refresh() {
-      this._comment.forEach(chat => {
+      var start = 0, end = this._comment.length;
+
+      if (this.isSimpleMode) {
+        let refreshCb = this._refreshCb = ((index, array) => {
+          if (refreshCb !== this._refreshCb) return;
+          if (index === array.length) {
+            this._refreshCb = null;
+            return;
+          }
+
+          var chat = array[index];
+
+          var size = this._calcSize(chat);
+          chat.width = size.width;
+          chat.height = size.height;
+
+          chat.y = this._calcY(chat);
+
+          setTimeout(refreshCb, 10, ++index, array);
+        }).bind(this);
+
+        let index = this._comment.reduce(((prev, chat, index) => {
+          if (chat.vpos >= this._position) return prev;
+          return index + 1;
+        }).bind(this), 0);
+
+        end = index;
+        start = Math.max(index - this._limit, 0);
+
+        setTimeout(refreshCb, 10, end, this._comment);
+      }
+
+      this._comment.slice(start, end).forEach(chat => {
         var size = this._calcSize(chat);
         chat.width = size.width;
         chat.height = size.height;
-      }, this);
 
-      this._comment.forEach(chat => {
         chat.y = this._calcY(chat);
       }, this);
     }
@@ -254,10 +304,12 @@
         size:       chat.size,
         visibility: false
       };
+
       var size = {
         width: dummy.width,
         height: dummy.height
       };
+
       dummy.chat = {};
 
       return size;
@@ -279,7 +331,8 @@
       const isUe = chat.position === "ue",
             isShita = chat.position === "shita",
             duration = (isUe || isShita) ? this._durationAlt : this._duration,
-            height = this._viewer.height;
+            height = this._viewer.height,
+            base = this.isSimpleMode ? Math.max(this._comment.indexOf(chat) - this._limit, 0) : 0;
 
       var y = 0,
           bullet = false;
@@ -287,14 +340,13 @@
       var loop = (() => {
         var flag = false;
 
-        this._comment.some(current => {
+        this._comment.slice(base).some(current => {
           const currentY = (isShita ? height - current.y  : current.y);
 
           if (current === chat) return true;
           if (current.position !== chat.position) return false;
           if (chat.vpos - current.vpos > duration) return false;
           if (y >= currentY + current.height || currentY >= y + chat.height) return false;
-          //if (current.bullet) return false;
 
           if (isUe || isShita) {
             y += current.height;


### PR DESCRIPTION
Viewerの_commentのtypoの修正とコメントの処理をしながら再生するシンプルモードの追加を行いました。
simpleLengthよりコメント数が多い場合はシンプルモードが適応されます。
シンプルモードで再生すると、再生時間+100ms程度の先読みをして表示をします。
時間軸のコメントの連続性は途切れてしまいますが、20000コメント超えでも再生しやすくなります。
