### PR TITLE
Fix the clickthrough mode detection for Linux

### DIFF
--- a/src/lib/windowWrapper.js
+++ b/src/lib/windowWrapper.js
@@ -9,6 +9,7 @@
   class WindowWrapper {
     constructor() {
       this.clickthrough = (() => {
+        if (gui.App.argv.indexOf("--enable-transparent-visuals") !== -1) return false; // For Linux
         if (gui.App.argv.indexOf("--disable-gpu") === -1) return false;
         if (gui.App.argv.indexOf("--force-cpu-draw") === -1) return false;
 


### PR DESCRIPTION
[nw.jsはLinuxでクリックスルーが使えない](https://github.com/nwjs/nw.js/wiki/Transparency#click-through-transparency)ので，`window.windowWrapper.clickthrough`が`false`になるように修正した
